### PR TITLE
Removed deprecated github option

### DIFF
--- a/bin/dt.bldr.sh
+++ b/bin/dt.bldr.sh
@@ -38,6 +38,7 @@
 #              : jan 15 2021  Make sure cloned repo is 100% clean
 #                             Disable integration test downloads       1.7.2
 #              : nov 16 2021  Removed obsolete CMake option            1.7.3
+#              : mar 16 2022  Removed obsolete github option           1.7.4
 # -------------------------------------------------------------------------- #
 # Copyright    : GNU General Public License v3.0
 #              : https://www.gnu.org/licenses/gpl-3.0.txt
@@ -51,7 +52,7 @@ LANG=POSIX; LC_ALL=POSIX; export LANG LC_ALL
 # --- Variables ---
 # ------------------------------------------------------------------ #
 # Script core related
-scriptVersion="1.7.3"
+scriptVersion="1.7.4"
 scriptName="$(basename "${0}")"
 # script directories
 scriptDir="/opt/dt.bldr"

--- a/bin/dt.cfg.sh
+++ b/bin/dt.cfg.sh
@@ -24,6 +24,7 @@
 #              : oct 16 2020 Fixed error triggered by using tab(s)     1.5.2
 #              : nov 14 2020 Added set compiler option                 1.7.0
 #              : nov 15 2020 Added latest option to check              1.7.1
+#              : mar 16 2022 Removed deprecated github option          1.7.2
 # -------------------------------------------------------------------------- #
 # Copyright    : GNU General Public License v3.0
 #              : https://www.gnu.org/licenses/gpl-3.0.txt
@@ -35,7 +36,7 @@ umask 026
 # --- Variables ---
 # ------------------------------------------------------------------ #
 # script core
-scriptVersion="1.7.1"
+scriptVersion="1.7.2"
 scriptName="$(basename "${0}")"
 # script directories
 scriptDir="/opt/dt.bldr"
@@ -90,9 +91,6 @@ function _doCheck ()
     if [ -z "${optsSRC[gitSRC]}" ]
     then
       STATUS="${clrRED}ERROR  - empty -${clrRST}" ; exitSTTS="253"
-    elif [[ ! "${optsSRC[gitSRC]}" =~ ^(git@github.com:|git://github.com/|https://github.com/) ]]
-    then
-      STATUS="${clrRED}ERROR${clrRST}" ; exitSTTS="252"
     fi
     printf "  %-28s%-18s%s\\n" "gitSRC" "${STATUS}" "${optsSRC[gitSRC]}"
     [ -z "${optsDRS[baseGitSrcDir]}" ] && \

--- a/cfg/README.configuration
+++ b/cfg/README.configuration
@@ -24,8 +24,8 @@ into a pull option and activate the stop-when-the-same option.
 The configuration file isn't limited to the darktable specific configuration,
 build and install options. The following can also be specified:
 
-+ The way the script connects with GitHub. Currently only 3 ways are
-  defined: https:// or git@ or git://
++ The way the script connects with GitHub. Currently only 2 ways are
+  defined: https:// or git@
 + The location of the log file(s),
 + The location of the git repository directory,
 + The percentage of cores to use during the build,

--- a/cfg/dt.bldr.cfg
+++ b/cfg/dt.bldr.cfg
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------------- #
 # Start /opt/dt.dt.bldr/cfg/dt.bldr.cfg
 # ---------------------------------------------------------------------------- #
-# cfgVersion="1.7.3"
+# cfgVersion="1.7.4"
 # ---------------------------------------------------------------------------- #
 #
 # Sensible fall-back configuration file for dt.bldr.sh
@@ -17,7 +17,6 @@
 useSRC="git"
 #  - remote protocols that can be used:
 #      smart http - https://github.com/darktable-org/darktable.git
-#      dumb http  - git://github.com/darktable-org/darktable.git
 #      ssh        - git@github.com:darktable-org/darktable.git
 gitSRC="https://github.com/darktable-org/darktable.git"
 #  - local tarball filename:


### PR DESCRIPTION
GitHub no longer supports git://. Removed that option from the files.