### PR TITLE
Ontw

### DIFF
--- a/bin/README.scripts
+++ b/bin/README.scripts
@@ -50,6 +50,10 @@ There's is a hidden option you can set to make merging multiple branches possibl
 
 If the -m options is used a clone is being forced (-c is used no matter the configuration setting). So there is no need to set -c (or -p) when using -m. This is also the case when using the hidden option.
 
+When multiple branches need to be integrated you need to merge these one at the time at the moment. There's no need to build and install for every branch, though. Use dt.bldr.sh -m for each branche untill all are merged and then run dt.bldr.sh -bi.
+
+To get rid of all the merged branches just run dt.bldr.sh -c, which will force a fresh clone.
+
 # -------------------------------------------------------------------------- #
 # dt.cfg.sh - the configuration checker
 

--- a/bin/README.scripts
+++ b/bin/README.scripts
@@ -42,6 +42,10 @@ installs more then just a few binaries. These would all end up in /bin when
 setting the global prefix to /bin. This can be fine-tuned on the configuration
 file though.
 
+The -t option takes care of the integration tests that come with darktable. The main reason for this script is to be able to build an install one or more personalized darktable versions and as such these integration tests are somewhat out-of-scope.
+
+The integration tests are rather large and are not being downloaded by default. There's a configuration option that can be set in dt.bldr.cfg to change this behaviour. 
+
 I decided to make it possible to merge a branch from a forked darktable repository into the current master. This is done using the -m options and a file called dt.ext.branch.cfg (must be located in ~/.local/cfg). This file holds the URL of the forked repository and the name of the branch (the example directory has a sample).
 
 **Beware:** This merge option (-m) is experimental. Merging might not work as intended depending on the branch that is being merged. Especially "old" PRs might introduce merging issues, the script is not intelligent enough to solve this.
@@ -73,14 +77,11 @@ If dt.cfg.sh is called without any option it defaults to -c
 
 # dt.cfg.sh -c  (or dt.cfg.sh)
 
-Do a rough check of the combined configuration files that are being used.
-There's no real intelligence, but it will point out common problems and
-mistakes.
+Do a rough check of the combined configuration files that are being used. There's no real intelligence, but it will point out common problems and mistakes.
 
 # dt.cfg.sh -s
 
-This will print all the options that are being used as well as some extra
-information relevant when building darktable.
+This will print all the options that are being used as well as some extra information relevant when building darktable.
 
 The extras:
 
@@ -91,10 +92,7 @@ The extras:
 
 # General
 
-This script will always start with the system-wide configuration file that
-can be found in /opt/dt.bldr/cfg and, if present, overlay the local copy.
-So even if you use a local configuration file that has a limited amount of
-entries the complete set of options is used/shown.
+This script will always start with the system-wide configuration file that can be found in /opt/dt.bldr/cfg and, if present, overlay the local copy. So even if you use a local configuration file that has a limited amount of entries the complete set of options is used/shown.
 
 # -------------------------------------------------------------------------- #
 # End

--- a/bin/README.scripts
+++ b/bin/README.scripts
@@ -3,20 +3,11 @@
 # -------------------------------------------------------------------------- #
 # dt.bldr.sh - the main script
 
-This script is what this project is all about and was created to make
-fetching, building and installing darktable easier and more flexible.
+This script is what this project is all about and was created to make fetching, building and installing darktable easier and more flexible.
 
-In essence there is nothing wrong at all with the "git version" instructions
-on the darktable website (right here: https://www.darktable.org/install/). But
-if you are like me and don't like doing things multiple times by hand, like to
-test specific options or build a version specific for your environment, you
-might want or need more flexibility.
+In essence there is nothing wrong at all with the "git version" instructions on the darktable website (right here: https://www.darktable.org/install/). But if you are like me and don't like doing things multiple times by hand, like to test specific options or build a version specific for your environment, you might want or need more flexibility.
 
-Checking if all the dependencies are met for building darktable and presenting
-them in a nice fashion is out of scope. The script will stop with a nice error
-message and all the output generated is put into a log file, so you do have a
-starting point to tackle the problem if you run into them. There's also an
-option in the config file that creates verbose logging if need be.
+Checking if all the dependencies are met for building darktable and presenting them in a nice fashion is out of scope. The script will stop with a nice error message and all the output generated is put into a log file, so you do have a starting point to tackle the problem if you run into them. There's also an option in the config file that creates verbose logging if need be.
 
 The following options can be used when running dt.bldr.sh:
 
@@ -28,33 +19,19 @@ The following options can be used when running dt.bldr.sh:
   -m    Merge one branch from a different remote repository
   -h/-? Show help
 
-If no options are given when running the script, the defaults that are in the
-global configuration file are being used.
+If no options are given when running the script, the defaults that are in the global configuration file are being used.
 
-The global/default configuration file (/opt/dt.dt.bldr/cfg/dt.bldr.cfg) is set
-to use -c and -b. I would recommend to set a sensible combo in the personalised
-config file ($HOME/.local/cfg/dt.bldr.cfg). I use the following default set: -p
--s -b -i (-psbi) Do have a look at the example configuration files present in the
-examples directory.
+The global/default configuration file (/opt/dt.dt.bldr/cfg/dt.bldr.cfg) is set to use -c and -b. I would recommend to set a sensible combo in the personalised config file ($HOME/.local/cfg/dt.bldr.cfg). I use the following default set: -p -s -b -i (-psbi) Do have a look at the example configuration files present in the examples directory.
 
-The clone and pull options (-c and -p) will also take care of the rawspeed
-module.
+The clone and pull options (-c and -p) will also take care of the rawspeed module.
 
-The -s option checks if the latest cloned/pulled git version is the same as
-the darktable version that is already installed. If this is the case then the
-build and/or install steps are skipped.
+The -s option checks if the latest cloned/pulled git version is the same as the darktable version that is already installed. If this is the case then the build and/or install steps are skipped.
 
-If ninja is installed it will _not_ be used out-of-the-box, you need to tell
-the script to use it by setting the appropriate option in the local copy of
-your dt.bldr.cfg file.
+If ninja is installed it will _not_ be used out-of-the-box, you need to tell the script to use it by setting the appropriate option in the local copy of your dt.bldr.cfg file.
 
-Out-of-the-box the script will use 75% of the cores available, using 'make
--jX'. This can also be adjusted in the configuration file. The current allowed
-range is 10% -> 200%
+Out-of-the-box the script will use 75% of the cores available, using 'make -jX'. This can also be adjusted in the configuration file. The current allowed range is 10% -> 200%
 
-In certain situations sudo will be used during the installation of darktable.
-At the moment the use of sudo will be triggered by the CMAKE_PREFIX_PATH
-variable starting with either of these three, making it a system wide install :
+In certain situations sudo will be used during the installation of darktable. At the moment the use of sudo will be triggered by the CMAKE_PREFIX_PATH variable starting with either of these three, making it a system wide install :
 
 * /opt/
 * /usr/
@@ -62,20 +39,16 @@ variable starting with either of these three, making it a system wide install :
 
 I strongly discourage using /bin as prefix because the installation process
 installs more then just a few binaries. These would all end up in /bin when
-setting the global prefix to /bin. This can be finetuned on the configuration
+setting the global prefix to /bin. This can be fine-tuned on the configuration
 file though.
 
-I decided to make it possible to merge a branch from a forked darktable
-repository into the current master. This is done using the -m options and a
-file called dt.ext.branch.cfg (must be located in ~/.local/cfg). This file
-holds the URL of the forked repository and the name of the branch (the example
-directory has a sample).
+I decided to make it possible to merge a branch from a forked darktable repository into the current master. This is done using the -m options and a file called dt.ext.branch.cfg (must be located in ~/.local/cfg). This file holds the URL of the forked repository and the name of the branch (the example directory has a sample).
 
-Beware: This merge option (-m) is experimental. Merging might not work
-as intended depending on the branch that is being merged.
+**Beware:** This merge option (-m) is experimental. Merging might not work as intended depending on the branch that is being merged. Especially "old" PRs might introduce merging issues, the script is not intelligent enough to solve this.
 
-If the -m options is used a clone is being forced (-c is used no matter the
-configuration setting). So there is no need to set -c (or -p) when using -m.
+There's is a hidden option you can set to make merging multiple branches possible: Look for *set preferred merge method* in dt.bldr.sh and set optClone and optClone to your preferred method.
+
+If the -m options is used a clone is being forced (-c is used no matter the configuration setting). So there is no need to set -c (or -p) when using -m. This is also the case when using the hidden option.
 
 # -------------------------------------------------------------------------- #
 # dt.cfg.sh - the configuration checker

--- a/bin/README.scripts
+++ b/bin/README.scripts
@@ -3,11 +3,20 @@
 # -------------------------------------------------------------------------- #
 # dt.bldr.sh - the main script
 
-This script is what this project is all about and was created to make fetching, building and installing darktable easier and more flexible.
+This script is what this project is all about and was created to make fetching,
+building and installing darktable easier and more flexible.
 
-In essence there is nothing wrong at all with the "git version" instructions on the darktable website (right here: https://www.darktable.org/install/). But if you are like me and don't like doing things multiple times by hand, like to test specific options or build a version specific for your environment, you might want or need more flexibility.
+In essence there is nothing wrong at all with the "git version" instructions on
+the darktable website (right here: https://www.darktable.org/install/). But if
+you are like me and don't like doing things multiple times by hand, like to
+test specific options or build a version specific for your environment, you
+might want or need more flexibility.
 
-Checking if all the dependencies are met for building darktable and presenting them in a nice fashion is out of scope. The script will stop with a nice error message and all the output generated is put into a log file, so you do have a starting point to tackle the problem if you run into them. There's also an option in the config file that creates verbose logging if need be.
+Checking if all the dependencies are met for building darktable and presenting
+them in a nice fashion is out of scope. The script will stop with a nice error
+message and all the output generated is put into a log file, so you do have a
+starting point to tackle the problem if you run into them. There's also an
+option in the config file that creates verbose logging if need be.
 
 The following options can be used when running dt.bldr.sh:
 
@@ -19,19 +28,33 @@ The following options can be used when running dt.bldr.sh:
   -m    Merge one branch from a different remote repository
   -h/-? Show help
 
-If no options are given when running the script, the defaults that are in the global configuration file are being used.
+If no options are given when running the script, the defaults that are in the
+global configuration file are being used.
 
-The global/default configuration file (/opt/dt.dt.bldr/cfg/dt.bldr.cfg) is set to use -c and -b. I would recommend to set a sensible combo in the personalised config file ($HOME/.local/cfg/dt.bldr.cfg). I use the following default set: -p -s -b -i (-psbi) Do have a look at the example configuration files present in the examples directory.
+The global/default configuration file (/opt/dt.dt.bldr/cfg/dt.bldr.cfg) is set
+to use -c and -b. I would recommend to set a sensible combo in the personalised
+config file ($HOME/.local/cfg/dt.bldr.cfg). I use the following default set: -p
+-s -b -i (-psbi) Do have a look at the example configuration files present in
+the examples directory.
 
-The clone and pull options (-c and -p) will also take care of the rawspeed module.
+The clone and pull options (-c and -p) will also take care of the rawspeed
+module.
 
-The -s option checks if the latest cloned/pulled git version is the same as the darktable version that is already installed. If this is the case then the build and/or install steps are skipped.
+The -s option checks if the latest cloned/pulled git version is the same as the
+darktable version that is already installed. If this is the case then the build
+and/or install steps are skipped.
 
-If ninja is installed it will _not_ be used out-of-the-box, you need to tell the script to use it by setting the appropriate option in the local copy of your dt.bldr.cfg file.
+If ninja is installed it will _not_ be used out-of-the-box, you need to tell
+the script to use it by setting the appropriate option in the local copy of
+your dt.bldr.cfg file.
 
-Out-of-the-box the script will use 75% of the cores available, using 'make -jX'. This can also be adjusted in the configuration file. The current allowed range is 10% -> 200%
+Out-of-the-box the script will use 75% of the cores available, using 'make
+-jX'. This can also be adjusted in the configuration file. The current allowed
+range is 10% -> 200%
 
-In certain situations sudo will be used during the installation of darktable. At the moment the use of sudo will be triggered by the CMAKE_PREFIX_PATH variable starting with either of these three, making it a system wide install :
+In certain situations sudo will be used during the installation of darktable.
+At the moment the use of sudo will be triggered by the CMAKE_PREFIX_PATH
+variable starting with either of these three, making it a system wide install :
 
 * /opt/
 * /usr/
@@ -42,21 +65,41 @@ installs more then just a few binaries. These would all end up in /bin when
 setting the global prefix to /bin. This can be fine-tuned on the configuration
 file though.
 
-The -t option takes care of the integration tests that come with darktable. The main reason for this script is to be able to build an install one or more personalized darktable versions and as such these integration tests are somewhat out-of-scope.
+The -t option takes care of the integration tests that come with darktable. The
+main reason for this script is to be able to build an install one or more
+personalized darktable versions and as such these integration tests are
+somewhat out-of-scope.
 
-The integration tests are rather large and are not being downloaded by default. There's a configuration option that can be set in dt.bldr.cfg to change this behaviour. 
+The integration tests are rather large and are not being downloaded by default.
+There's a configuration option that can be set in dt.bldr.cfg to change this
+behaviour. 
 
-I decided to make it possible to merge a branch from a forked darktable repository into the current master. This is done using the -m options and a file called dt.ext.branch.cfg (must be located in ~/.local/cfg). This file holds the URL of the forked repository and the name of the branch (the example directory has a sample).
+I decided to make it possible to merge a branch from a forked darktable
+repository into the current master. This is done using the -m options and a
+file called dt.ext.branch.cfg (must be located in ~/.local/cfg). This file
+holds the URL of the forked repository and the name of the branch (the example
+directory has a sample).
 
-**Beware:** This merge option (-m) is experimental. Merging might not work as intended depending on the branch that is being merged. Especially "old" PRs might introduce merging issues, the script is not intelligent enough to solve this.
+**Beware:** This merge option (-m) is experimental. Merging might not work as
+intended depending on the branch that is being merged. Especially "old" PRs
+might introduce merging issues, the script is not intelligent enough to solve
+this.
 
-There's is a hidden option you can set to make merging multiple branches possible: Look for *set preferred merge method* in dt.bldr.sh and set optClone and optClone to your preferred method.
+There's is a hidden option you can set to make merging multiple branches
+possible: Look for *set preferred merge method* in dt.bldr.sh and set optClone
+and optClone to your preferred method.
 
-If the -m options is used a clone is being forced (-c is used no matter the configuration setting). So there is no need to set -c (or -p) when using -m. This is also the case when using the hidden option.
+If the -m options is used a clone is being forced (-c is used no matter the
+configuration setting). So there is no need to set -c (or -p) when using -m.
+This is also the case when using the hidden option.
 
-When multiple branches need to be integrated you need to merge these one at the time at the moment. There's no need to build and install for every branch, though. Use dt.bldr.sh -m for each branche untill all are merged and then run dt.bldr.sh -bi.
+When multiple branches need to be integrated you need to merge these one at the
+time at the moment. There's no need to build and install for every branch,
+though. Use dt.bldr.sh -m for each branche untill all are merged and then run
+dt.bldr.sh -bi.
 
-To get rid of all the merged branches just run dt.bldr.sh -c, which will force a fresh clone.
+To get rid of all the merged branches just run dt.bldr.sh -c, which will force
+a fresh clone.
 
 # -------------------------------------------------------------------------- #
 # dt.cfg.sh - the configuration checker
@@ -77,11 +120,14 @@ If dt.cfg.sh is called without any option it defaults to -c
 
 # dt.cfg.sh -c  (or dt.cfg.sh)
 
-Do a rough check of the combined configuration files that are being used. There's no real intelligence, but it will point out common problems and mistakes.
+Do a rough check of the combined configuration files that are being used.
+There's no real intelligence, but it will point out common problems and
+mistakes.
 
 # dt.cfg.sh -s
 
-This will print all the options that are being used as well as some extra information relevant when building darktable.
+This will print all the options that are being used as well as some extra
+information relevant when building darktable.
 
 The extras:
 
@@ -92,7 +138,10 @@ The extras:
 
 # General
 
-This script will always start with the system-wide configuration file that can be found in /opt/dt.bldr/cfg and, if present, overlay the local copy. So even if you use a local configuration file that has a limited amount of entries the complete set of options is used/shown.
+This script will always start with the system-wide configuration file that can
+be found in /opt/dt.bldr/cfg and, if present, overlay the local copy. So even
+if you use a local configuration file that has a limited amount of entries the
+complete set of options is used/shown.
 
 # -------------------------------------------------------------------------- #
 # End


### PR DESCRIPTION
Made it possible to merge more then one external branch. This is, however, not enabled by default.

The default still forces a clean clone before merging one external branch. There's a hidden option (see README.scripts) that allows for multiple mergers and thus also uses a pull instead of a clone.

Decided to do it this way to make sure this is very consciously enabled and not an option that can be enabled accidentally.