### PR TITLE
fixing: versioning issue + cmake messages

### DIFF
--- a/bin/dt.bldr.sh
+++ b/bin/dt.bldr.sh
@@ -46,6 +46,7 @@
 #              : oct 26 2022  Include HEIF, ISOBMFF and JXL support    2.1.0
 #              : oct 26 2022  Include ICU, LIBRAW and PORTMIDI support 2.1.1
 #              : oct 26 2022  Fixed a deleted char in help section     2.1.2
+#              : oct 13 2023  Fixed versioning change issue            2.1.3
 # -------------------------------------------------------------------------- #
 # Copyright    : GNU General Public License v3.0
 #              : https://www.gnu.org/licenses/gpl-3.0.txt
@@ -59,7 +60,7 @@ LANG=POSIX; LC_ALL=POSIX; export LANG LC_ALL
 # --- Variables ---
 # ------------------------------------------------------------------ #
 # Script core related
-scriptVersion="2.1.2"
+scriptVersion="2.1.3"
 scriptName="$(basename "${0}")"
 # script directories
 scriptDir="/opt/dt.bldr"
@@ -649,7 +650,7 @@ makeOpts="-j ${nmbrCores}"
 [ -e "${CMAKE_PREFIX_PATH}/bin/darktable" ] && \
   [ -x "${CMAKE_PREFIX_PATH}/bin/darktable" ] && \
     curVrsn="$("${CMAKE_PREFIX_PATH}/bin/darktable" --version | \
-    sed 's/[~+]/-/g' | awk 'NR==1 { print $4 }')"
+    sed -e 's/this is //' -e 's/\-dirty//' -e 's/[~+]/-/g' | awk 'NR==1 { print $2 }')"
 
 # -------------------------------------------------------------------------- #
 # set env for remote (git) or local (tarball) source

--- a/bin/dt.bldr.sh
+++ b/bin/dt.bldr.sh
@@ -47,6 +47,7 @@
 #              : oct 26 2022  Include ICU, LIBRAW and PORTMIDI support 2.1.1
 #              : oct 26 2022  Fixed a deleted char in help section     2.1.2
 #              : oct 13 2023  Fixed versioning change issue            2.1.3
+#              : oct 15 2023  Fixed "Ignore extra path.." issue        2.1.4
 # -------------------------------------------------------------------------- #
 # Copyright    : GNU General Public License v3.0
 #              : https://www.gnu.org/licenses/gpl-3.0.txt
@@ -60,7 +61,7 @@ LANG=POSIX; LC_ALL=POSIX; export LANG LC_ALL
 # --- Variables ---
 # ------------------------------------------------------------------ #
 # Script core related
-scriptVersion="2.1.3"
+scriptVersion="2.1.4"
 scriptName="$(basename "${0}")"
 # script directories
 scriptDir="/opt/dt.bldr"
@@ -296,8 +297,8 @@ function _gitDtBuild ()
         -DBUILD_USERMANUAL="${BUILD_USERMANUAL}" \
         -DBINARY_PACKAGE_BUILD="${BINARY_PACKAGE_BUILD}" \
         -DTESTBUILD_OPENCL_PROGRAMS="${TESTBUILD_OPENCL_PROGRAMS}" \
-        CMAKE_C_FLAGS="${CMAKE_FLAGS}" \
-        CMAKE_CXX_FLAGS="${CMAKE_FLAGS}" \
+        -DCMAKE_C_FLAGS="${CMAKE_FLAGS}" \
+        -DCMAKE_CXX_FLAGS="${CMAKE_FLAGS}" \
         -G "${cmakeGen}" \
         .. >> "${bldLog}" 2>&1 &
   prcssPid="$!" ; txtStrng="build   - configuring darktable using cmake"


### PR DESCRIPTION
1) Versioning issue:

Darktable changed the way it shows its version. dt.bldr.sh needs to be adjusted to accommodate that.

Fixed by: b9b8b65

2) Some Linux distro's show a warning when using cmake. Cmake seems to be working fine as-is but a fix would be preferable.

Fixed by: caa3c86 and this fixes issue #26