### PR TITLE
added screen message when integration tests are not disabled

### DIFF
--- a/bin/dt.bldr.sh.bak
+++ b/bin/dt.bldr.sh.bak
@@ -162,8 +162,6 @@ function _gitDtClone ()
     printf "\\r          - disabling integration tests"
     git config submodule.src/tests/integration.update none  >> "${bldLog}" 2>&1 || _errHndlr "_gitDtClone" "disable integration test"
     printf "\\r          - disabling integration tests %sOK%s\\n" "${clrGRN}" "${clrRST}"
-  else
-    printf "\\r          - integration tests are not disabled \\n"
   fi
   # initialize rawspeed
   printf "\\r          - initializing and updating rawspeed"


### PR DESCRIPTION
at the moment when -t is used or dfltTest is set to 1 in the config file it is not communicated that this is the case.